### PR TITLE
Use new URL Parser when handling Cosmos connection string

### DIFF
--- a/api/models/store.js
+++ b/api/models/store.js
@@ -28,7 +28,7 @@ async function configureMongoose(log) {
 
         await mongoose.connect(
             config.database.connectionString,
-            { dbName: config.database.databaseName }
+            { dbName: config.database.databaseName, useNewUrlParser: true }
         );
     }
     catch (err) {


### PR DESCRIPTION

When deploying this example using a Comsos for Mongo API connection, I was receiving the error below, this fixes it:


```Exception while executing function: Functions.lists Result: Failure
Exception: Error: Password contains an illegal unescaped character
Stack: Error: Password contains an illegal unescaped character
    at parseConnectionString (/home/site/wwwroot/node_modules/mongodb/lib/url_parser.js:305:13)
    at parseHandler (/home/site/wwwroot/node_modules/mongodb/lib/url_parser.js:136:14)
    at module.exports (/home/site/wwwroot/node_modules/mongodb/lib/url_parser.js:28:12)
    at deprecated (internal/util.js:89:15)
    at connect (/home/site/wwwroot/node_modules/mongodb/lib/operations/connect.js:282:3)
    at /home/site/wwwroot/node_modules/mongodb/lib/mongo_client.js:260:5
    at maybePromise (/home/site/wwwroot/node_modules/mongodb/lib/utils.js:692:3)
    at MongoClient.connect (/home/site/wwwroot/node_modules/mongodb/lib/mongo_client.js:256:10)
    at /home/site/wwwroot/node_modules/mongoose/lib/connection.js:835:12
    at new Promise (<anonymous>)
    at NativeConnection.Connection.openUri (/home/site/wwwroot/node_modules/mongoose/lib/connection.js:832:19)
    at /home/site/wwwroot/node_modules/mongoose/lib/index.js:351:10
    at /home/site/wwwroot/node_modules/mongoose/lib/helpers/promiseOrCallback.js:32:5
    at new Promise (<anonymous>)
    at promiseOrCallback (/home/site/wwwroot/node_modules/mongoose/lib/helpers/promiseOrCallback.js:31:10)
    at Mongoose._promiseOrCallback (/home/site/wwwroot/node_modules/mongoose/lib/index.js:1149:10)
```